### PR TITLE
[!!!][FEATURE] Drop global storage pid in favor of command argument

### DIFF
--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -59,19 +59,4 @@ final class ExtensionConfiguration
 
         return new Uri($apiUrl);
     }
-
-    public function getStoragePid(): int
-    {
-        try {
-            $jobPid = $this->configuration->get(Extension::KEY, 'storagePid');
-        } catch (Exception) {
-            return 0;
-        }
-
-        if (!is_numeric($jobPid) || $jobPid <= 0) {
-            return 0;
-        }
-
-        return (int)$jobPid;
-    }
 }

--- a/Classes/Domain/Repository/JobRepository.php
+++ b/Classes/Domain/Repository/JobRepository.php
@@ -23,10 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\Typo3PersonioJobs\Domain\Repository;
 
-use CPSIT\Typo3PersonioJobs\Configuration\ExtensionConfiguration;
 use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -40,15 +37,6 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class JobRepository extends Repository
 {
-    public function initializeObject(): void
-    {
-        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        $querySettings = GeneralUtility::makeInstance(QuerySettingsInterface::class);
-        $querySettings->setStoragePageIds([$extensionConfiguration->getStoragePid()]);
-
-        $this->defaultQuerySettings = $querySettings;
-    }
-
     public function findOneByPersonioId(int $personioId): ?Job
     {
         $query = $this->createQuery();
@@ -71,9 +59,13 @@ class JobRepository extends Repository
      * @param list<Job> $existingJobs
      * @return QueryResultInterface<Job>
      */
-    public function findOrphans(array $existingJobs): QueryResultInterface
+    public function findOrphans(array $existingJobs, int $storagePid = null): QueryResultInterface
     {
         $query = $this->createQuery();
+
+        if ($storagePid !== null) {
+            $query->getQuerySettings()->setStoragePageIds([$storagePid]);
+        }
 
         if ($existingJobs !== []) {
             $query->matching(

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ The extension provides two plugins:
 #### `personio-jobs:import`
 
 ```bash
-typo3 personio-jobs:import [--force] [--no-delete] [--no-update] [--dry-run]
+typo3 personio-jobs:import <storage-pid> [options]
 ```
 
 The following command parameters are available:
 
 | Command parameter       | Description                                              | Required | Default |
 |-------------------------|----------------------------------------------------------|----------|---------|
+| **`storage-pid`**       | Storage pid of imported jobs                             | ✅        | –       |
 | **`-f`**, **`--force`** | Enforce re-import of unchanged jobs                      | –        | no      |
 | **`--no-delete`**       | Do not delete orphaned jobs                              | –        | no      |
 | **`--no-update`**       | Do not update imported jobs that have been changed       | –        | no      |
@@ -119,7 +120,6 @@ The following extension configuration options are available:
 | Configuration key | Description                                                          | Required | Default |
 |-------------------|----------------------------------------------------------------------|----------|---------|
 | **`apiUrl`**      | URL to Personio job page, e.g. `https://my-company.jobs.personio.de` | ✅        | –       |
-| **`storagePid`**  | UID of the page under which the job pages are persisted              | ✅        | `0`     |
 
 ### Routing configuration
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,2 @@
 # cat=basic; type=string; label=URL to Personio job page:e.g. https://my-company.jobs.personio.de
 apiUrl =
-
-# cat=basic; type=int+; label=Storage pid: UID of the page under which the job pages are persisted
-storagePid = 0


### PR DESCRIPTION
The extension configuration `storagePid` is removed and replaced by a command argument `storage-pid`.

## Migration

### Command-line

Instead of configuring the storage pid via extension configuration, pass it as command argument instead:

```bash
typo3 personio-jobs:import <storage-pid> [options]
```

### List plugin

Use TYPO3's native `pages` field in the plugin instead.