### PR TITLE
[BUGFIX] Configure target branch for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
+    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -18,6 +19,7 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
+    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -28,6 +30,7 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
+    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10


### PR DESCRIPTION
Since we're using Git Flow in this repository, Dependabot updates must be performed against the `develop` branch.