### PR TITLE
[BUGFIX] Do not strip tags in job description

### DIFF
--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -232,6 +232,6 @@ class JobController extends ActionController
             $parsedDescription = $this->contentObjectRenderer->parseFunc($description, [], '< lib.parseFunc_RTE');
         }
 
-        return strip_tags($parsedDescription, '<p>');
+        return $parsedDescription;
     }
 }


### PR DESCRIPTION
It's actually not required to only keep `<p>` tags in job descriptions that are parsed as structured content on job detail pages. Thus, the `strip_tags` function is now removed.