### PR TITLE
[!!!][FEATURE] Move JobPosting schema generation to dedicated factory

### DIFF
--- a/Classes/Domain/Factory/SchemaFactory.php
+++ b/Classes/Domain/Factory/SchemaFactory.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Domain\Factory;
+
+use Brotkrueml\Schema\Model\Type\JobPosting;
+use Brotkrueml\Schema\Model\Type\Organization;
+use Brotkrueml\Schema\Model\Type\Place;
+use Brotkrueml\Schema\Type\TypeFactory;
+use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
+use CPSIT\Typo3PersonioJobs\Enums\Job\EmploymentType;
+use CPSIT\Typo3PersonioJobs\Enums\Job\Schedule;
+use CPSIT\Typo3PersonioJobs\Enums\Schema\EmploymentType as EmploymentTypeSchema;
+use CPSIT\Typo3PersonioJobs\Exception\ExtensionNotLoadedException;
+use CPSIT\Typo3PersonioJobs\Service\PersonioService;
+use CPSIT\Typo3PersonioJobs\Utility\FrontendUtility;
+use DateTime;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * SchemaFactory
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class SchemaFactory
+{
+    public function __construct(
+        protected readonly PersonioService $personioService,
+        protected readonly ContentObjectRenderer $contentObjectRenderer,
+    ) {
+    }
+
+    /**
+     * @throws ExtensionNotLoadedException
+     */
+    public function createJobPosting(Job $job): JobPosting
+    {
+        // Throw exception if schema extension is not installed
+        if (!ExtensionManagementUtility::isLoaded('schema')) {
+            throw ExtensionNotLoadedException::create('schema');
+        }
+
+        $serverRequest = FrontendUtility::getServerRequest();
+        $organizationType = $this->createOrganization($job);
+        $placeType = $this->createPlace($job);
+
+        /** @var JobPosting $jobPosting */
+        $jobPosting = TypeFactory::createType('JobPosting')
+            ->setProperty('datePosted', ($job->getCreateDate() ?? new DateTime())->format('Y-m-d'))
+            ->setProperty('employmentType', $this->decorateEmploymentType($job))
+            ->setProperty('hiringOrganization', $organizationType)
+            ->setProperty('jobLocation', $placeType)
+            ->setProperty('occupationalCategory', $job->getOccupationCategory())
+            ->setProperty('title', $job->getName())
+            ->setProperty('description', $this->decorateDescription($job))
+            ->setProperty('url', (string)$serverRequest->getUri())
+            ->setProperty('sameAs', (string)$this->personioService->getJobUrl($job))
+        ;
+
+        return $jobPosting;
+    }
+
+    protected function createOrganization(Job $job): Organization
+    {
+        /** @var Organization $organization */
+        $organization = TypeFactory::createType('Organization')
+            ->setProperty('name', $job->getSubcompany())
+            ->setProperty('address', $job->getOffice())
+        ;
+
+        return $organization;
+    }
+
+    protected function createPlace(Job $job): Place
+    {
+        /** @var Place $place */
+        $place = TypeFactory::createType('Place')
+            ->setProperty('address', $job->getOffice())
+        ;
+
+        return $place;
+    }
+
+    /**
+     * @return value-of<EmploymentTypeSchema>|list<value-of<EmploymentTypeSchema>>
+     * @see https://developers.google.com/search/docs/appearance/structured-data/job-posting#job-posting-definition
+     */
+    protected function decorateEmploymentType(Job $job): string|array
+    {
+        $employmentType = EmploymentType::tryFrom($job->getEmploymentType());
+        $schedule = Schedule::tryFrom($job->getSchedule());
+
+        if ($employmentType === null && $schedule === null) {
+            return EmploymentTypeSchema::Other->value;
+        }
+
+        if ($employmentType === EmploymentType::Intern) {
+            return EmploymentTypeSchema::Intern->value;
+        }
+
+        return match ($schedule) {
+            Schedule::FullTime => EmploymentTypeSchema::FullTime->value,
+            Schedule::PartTime => EmploymentTypeSchema::PartTime->value,
+            Schedule::FullOrPartTime => [EmploymentTypeSchema::FullTime->value, EmploymentTypeSchema::PartTime->value],
+            null => EmploymentTypeSchema::Other->value,
+        };
+    }
+
+    protected function decorateDescription(Job $job): string
+    {
+        $description = '';
+
+        foreach ($job->getJobDescriptions() as $jobDescription) {
+            $rawJobDescription = $jobDescription->getBodytext();
+            $description .= $rawJobDescription . ' ';
+        }
+
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            // https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96520-EnforceNon-emptyConfigurationInCObjparseFunc.html
+            $parsedDescription = $this->contentObjectRenderer->parseFunc($description, null, '< lib.parseFunc_RTE');
+        } else {
+            /* @phpstan-ignore-next-line */
+            $parsedDescription = $this->contentObjectRenderer->parseFunc($description, [], '< lib.parseFunc_RTE');
+        }
+
+        return $parsedDescription;
+    }
+}

--- a/Classes/Enums/Schema/EmploymentType.php
+++ b/Classes/Enums/Schema/EmploymentType.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Enums\Schema;
+
+/**
+ * EmploymentType
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+enum EmploymentType: string
+{
+    case FullTime = 'FULL_TIME';
+    case Intern = 'INTERN';
+    case Other = 'OTHER';
+    case PartTime = 'PART_TIME';
+}

--- a/Classes/Exception/ExtensionNotLoadedException.php
+++ b/Classes/Exception/ExtensionNotLoadedException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Exception;
+
+use Exception;
+
+/**
+ * ExtensionNotLoadedException
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class ExtensionNotLoadedException extends Exception
+{
+    public static function create(string $extensionKey): self
+    {
+        return new self(
+            sprintf('The extension "%s" is not loaded.', $extensionKey),
+            1680171538,
+        );
+    }
+}

--- a/Classes/Service/PersonioService.php
+++ b/Classes/Service/PersonioService.php
@@ -27,6 +27,7 @@ use CPSIT\Typo3PersonioJobs\Configuration\ExtensionConfiguration;
 use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
 use CPSIT\Typo3PersonioJobs\Domain\Model\JobDescription;
 use CPSIT\Typo3PersonioJobs\Exception\MalformedApiResponseException;
+use CPSIT\Typo3PersonioJobs\Utility\FrontendUtility;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\Mapper\Tree\Message\Messages;
@@ -73,6 +74,24 @@ final class PersonioService
 
             throw MalformedApiResponseException::forMappingErrors($errors);
         }
+    }
+
+    public function getJobUrl(Job $job): Uri
+    {
+        $serverRequest = FrontendUtility::getServerRequest();
+        $language = $serverRequest->getAttribute('language')?->getTwoLetterIsoCode();
+        $jobUrl = $this->apiUrl->withPath(sprintf('/job/%d', $job->getPersonioId()));
+
+        if ($language !== null) {
+            $jobUrl = $jobUrl->withQuery(sprintf('?language=%s', $language));
+        }
+
+        return $jobUrl;
+    }
+
+    public function getApplyUrl(Job $job): Uri
+    {
+        return $this->getJobUrl($job)->withFragment('apply');
     }
 
     private function createMapper(): TreeMapper

--- a/Classes/Utility/FrontendUtility.php
+++ b/Classes/Utility/FrontendUtility.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Utility;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
+
+/**
+ * FrontendUtility
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class FrontendUtility
+{
+    public static function getServerRequest(): ServerRequestInterface
+    {
+        $serverRequest = $GLOBALS['TYPO3_REQUEST'] ?? null;
+
+        if ($serverRequest instanceof ServerRequestInterface) {
+            return $serverRequest;
+        }
+
+        return ServerRequestFactory::fromGlobals();
+    }
+}


### PR DESCRIPTION
The generation of the `JobPosting` schema is moved to a dedicated `SchemaFactory`, making it easier to extend the generated schema as desired. In addition, the `PersonioService` now handles generation for job url and apply url.

This PR also replaces the `relevantOccupation` property from the `JobPosting` schema by the `occupationalCategory` property. In addition, the `sameAs` property is now populated, linking to the Personio job detail page.