### PR TITLE
[FEATURE] Allow sorting of jobs in list plugin via flexform

### DIFF
--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -26,6 +26,7 @@ namespace CPSIT\Typo3PersonioJobs\Controller;
 use Brotkrueml\Schema\Manager\SchemaManager;
 use CPSIT\Typo3PersonioJobs\Cache\CacheManager;
 use CPSIT\Typo3PersonioJobs\Domain\Factory\SchemaFactory;
+use CPSIT\Typo3PersonioJobs\Domain\Model\Dto\ListDemand;
 use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
 use CPSIT\Typo3PersonioJobs\Domain\Repository\JobRepository;
 use CPSIT\Typo3PersonioJobs\Exception\ExtensionNotLoadedException;
@@ -58,7 +59,8 @@ class JobController extends ActionController
     {
         $this->cacheManager->addTag();
 
-        $jobs = $this->jobRepository->findAll();
+        $demand = ListDemand::fromArray($this->settings);
+        $jobs = $this->jobRepository->findByDemand($demand);
 
         $this->view->assign('jobs', $jobs);
 

--- a/Classes/Domain/Model/Dto/Demand.php
+++ b/Classes/Domain/Model/Dto/Demand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Domain\Model\Dto;
+
+use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+/**
+ * Demand
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+interface Demand
+{
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public static function fromArray(array $settings): static;
+
+    /**
+     * @param QueryInterface<Job> $query
+     */
+    public function apply(QueryInterface $query): void;
+}

--- a/Classes/Domain/Model/Dto/ListDemand.php
+++ b/Classes/Domain/Model/Dto/ListDemand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Domain\Model\Dto;
+
+use CPSIT\Typo3PersonioJobs\Enums\SortingDirection;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+/**
+ * ListDemand
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class ListDemand implements Demand
+{
+    protected string $sorting = '';
+    protected SortingDirection $sortingDirection = SortingDirection::Ascending;
+
+    final protected function __construct()
+    {
+    }
+
+    /**
+     * @param array{sorting?: string, sortingDirection?: value-of<SortingDirection>} $settings
+     */
+    public static function fromArray(array $settings): static
+    {
+        $demand = new static();
+        $demand->sorting = $settings['sorting'] ?? '';
+        $demand->sortingDirection = SortingDirection::fromCaseInsensitive($settings['sortingDirection'] ?? 'asc');
+
+        return $demand;
+    }
+
+    public function apply(QueryInterface $query): void
+    {
+        if ($this->sorting !== '') {
+            $query->setOrderings([
+                $this->sorting => $this->sortingDirection->value,
+            ]);
+        }
+    }
+
+    public function getSorting(): string
+    {
+        return $this->sorting;
+    }
+
+    public function setSorting(string $sorting): self
+    {
+        $this->sorting = trim($sorting);
+        return $this;
+    }
+
+    public function getSortingDirection(): SortingDirection
+    {
+        return $this->sortingDirection;
+    }
+
+    public function setSortingDirection(SortingDirection $sortingDirection): self
+    {
+        $this->sortingDirection = $sortingDirection;
+        return $this;
+    }
+}

--- a/Classes/Domain/Repository/JobRepository.php
+++ b/Classes/Domain/Repository/JobRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace CPSIT\Typo3PersonioJobs\Domain\Repository;
 
+use CPSIT\Typo3PersonioJobs\Domain\Model\Dto\Demand;
 use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
@@ -37,6 +38,17 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class JobRepository extends Repository
 {
+    /**
+     * @return QueryResultInterface<Job>
+     */
+    public function findByDemand(Demand $demand): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        $demand->apply($query);
+
+        return $query->execute();
+    }
+
     public function findOneByPersonioId(int $personioId, int $storagePid = null): ?Job
     {
         $query = $this->createQuery();

--- a/Classes/Enums/SortingDirection.php
+++ b/Classes/Enums/SortingDirection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Enums;
+
+/**
+ * SortingDirection
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+enum SortingDirection: string
+{
+    case Ascending = 'ASC';
+    case Descending = 'DESC';
+
+    public static function fromCaseInsensitive(string $value): self
+    {
+        return self::from(strtoupper($value));
+    }
+}

--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -14,6 +14,52 @@
                     </config>
                 </TCEforms>
             </settings.detailPid>
+            <settings.sorting>
+                <TCEforms>
+                    <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting</label>
+                    <config>
+                        <type>select</type>
+                        <renderType>selectSingle</renderType>
+                        <items>
+                            <numIndex index="0">
+                                <numIndex index="0"></numIndex>
+                                <numIndex index="1"></numIndex>
+                            </numIndex>
+                            <numIndex index="1">
+                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.sorting</numIndex>
+                                <numIndex index="1">sorting</numIndex>
+                            </numIndex>
+                            <numIndex index="2">
+                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.name</numIndex>
+                                <numIndex index="1">name</numIndex>
+                            </numIndex>
+                            <numIndex index="3">
+                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.create_date</numIndex>
+                                <numIndex index="1">create_date</numIndex>
+                            </numIndex>
+                        </items>
+                    </config>
+                </TCEforms>
+            </settings.sorting>
+            <settings.sortingDirection>
+                <TCEforms>
+                    <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection</label>
+                    <config>
+                        <type>select</type>
+                        <renderType>selectSingle</renderType>
+                        <items>
+                            <numIndex index="0">
+                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.asc</numIndex>
+                                <numIndex index="1">asc</numIndex>
+                            </numIndex>
+                            <numIndex index="1">
+                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.desc</numIndex>
+                                <numIndex index="1">desc</numIndex>
+                            </numIndex>
+                        </items>
+                    </config>
+                </TCEforms>
+            </settings.sortingDirection>
         </el>
     </ROOT>
 </extra>

--- a/Configuration/TCA/tx_personiojobs_domain_model_job.php
+++ b/Configuration/TCA/tx_personiojobs_domain_model_job.php
@@ -30,6 +30,7 @@ return [
         'crdate' => 'crdate',
         'title' => 'LLL:EXT:personio_jobs/Resources/Private/Language/locallang_db.xlf:tx_personiojobs_domain_model_job',
         'delete' => 'deleted',
+        'sortby' => 'sorting',
         'enablecolumns' => [
             'disabled' => 'hidden',
             'starttime' => 'starttime',

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -23,6 +23,27 @@
 			<trans-unit id="flexforms.list.settings.detailPid">
 				<source>Detail page</source>
 			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sorting">
+				<source>Sort by</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sorting.sorting">
+				<source>Sorting</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sorting.name">
+				<source>Name</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sorting.create_date">
+				<source>Create date</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sortingDirection">
+				<source>Sorting direction</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sortingDirection.asc">
+				<source>ascending</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.sortingDirection.desc">
+				<source>descending</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
This PR enables `sorting` for jobs. In addition, it extends the list flexform to allow sorting by `sorting`, `name` and `create_date`. For this, a new `Demand` interface is added with a concrete `ListDemand` implementation. Jobs can now also be queried by using the new `JobRepository::findByDemand()` method.