### PR TITLE
[FEATURE] Introduce filter for subcompany within list plugin

### DIFF
--- a/Classes/Domain/Model/Dto/Filter.php
+++ b/Classes/Domain/Model/Dto/Filter.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Domain\Model\Dto;
+
+use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\Generic\Qom\ConstraintInterface;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+/**
+ * Filter
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ *
+ * @phpstan-type FilterSettings array{
+ *     subcompany_include?: string,
+ *     subcompany_exclude?: string,
+ * }
+ */
+class Filter
+{
+    /**
+     * @var list<string>
+     */
+    protected array $subcompanyInclude;
+
+    /**
+     * @var list<string>
+     */
+    protected array $subcompanyExclude;
+
+    final protected function __construct()
+    {
+        $this->subcompanyInclude = [];
+        $this->subcompanyExclude = [];
+    }
+
+    /**
+     * @phpstan-param FilterSettings $settings
+     */
+    public static function fromArray(array $settings): static
+    {
+        $filter = new static();
+        $filter->subcompanyInclude = GeneralUtility::trimExplode(',', $settings['subcompany_include'] ?? '', true);
+        $filter->subcompanyExclude = GeneralUtility::trimExplode(',', $settings['subcompany_exclude'] ?? '', true);
+
+        return $filter;
+    }
+
+    /**
+     * @param QueryInterface<Job> $query
+     */
+    public function buildConstraint(QueryInterface $query): ConstraintInterface
+    {
+        $constraints = [];
+
+        if ($this->subcompanyInclude !== []) {
+            $constraints[] = $query->in('subcompany', $this->subcompanyInclude);
+        }
+
+        if ($this->subcompanyExclude !== []) {
+            $constraints[] = $query->logicalNot(
+                $query->in('subcompany', $this->subcompanyExclude),
+            );
+        }
+
+        return $query->logicalAnd(...$constraints);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSubcompanyInclude(): array
+    {
+        return $this->subcompanyInclude;
+    }
+
+    /**
+     * @param list<string> $subcompanyInclude
+     */
+    public function setSubcompanyInclude(array $subcompanyInclude): static
+    {
+        $this->subcompanyInclude = $subcompanyInclude;
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSubcompanyExclude(): array
+    {
+        return $this->subcompanyExclude;
+    }
+
+    /**
+     * @param list<string> $subcompanyExclude
+     */
+    public function setSubcompanyExclude(array $subcompanyExclude): static
+    {
+        $this->subcompanyExclude = $subcompanyExclude;
+        return $this;
+    }
+}

--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -1,65 +1,102 @@
-<extra>
-    <ROOT>
-        <type>array</type>
-        <el>
-            <settings.detailPid>
+<T3DataStructure>
+    <sheets>
+        <sDEF>
+            <ROOT>
                 <TCEforms>
-                    <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.detailPid</label>
-                    <config>
-                        <type>group</type>
-                        <allowed>pages</allowed>
-                        <minitems>1</minitems>
-                        <maxitems>1</maxitems>
-                        <size>1</size>
-                    </config>
+                    <sheetTitle>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.tab.settings</sheetTitle>
                 </TCEforms>
-            </settings.detailPid>
-            <settings.sorting>
+                <type>array</type>
+                <el>
+                    <settings.detailPid>
+                        <TCEforms>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.detailPid</label>
+                            <config>
+                                <type>group</type>
+                                <allowed>pages</allowed>
+                                <minitems>1</minitems>
+                                <maxitems>1</maxitems>
+                                <size>1</size>
+                            </config>
+                        </TCEforms>
+                    </settings.detailPid>
+                    <settings.sorting>
+                        <TCEforms>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="0">
+                                        <numIndex index="0"></numIndex>
+                                        <numIndex index="1"></numIndex>
+                                    </numIndex>
+                                    <numIndex index="1">
+                                        <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.sorting</numIndex>
+                                        <numIndex index="1">sorting</numIndex>
+                                    </numIndex>
+                                    <numIndex index="2">
+                                        <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.name</numIndex>
+                                        <numIndex index="1">name</numIndex>
+                                    </numIndex>
+                                    <numIndex index="3">
+                                        <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.create_date</numIndex>
+                                        <numIndex index="1">create_date</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.sorting>
+                    <settings.sortingDirection>
+                        <TCEforms>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items>
+                                    <numIndex index="0">
+                                        <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.asc</numIndex>
+                                        <numIndex index="1">asc</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1">
+                                        <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.desc</numIndex>
+                                        <numIndex index="1">desc</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </settings.sortingDirection>
+                </el>
+            </ROOT>
+        </sDEF>
+        <filter>
+            <ROOT>
                 <TCEforms>
-                    <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting</label>
-                    <config>
-                        <type>select</type>
-                        <renderType>selectSingle</renderType>
-                        <items>
-                            <numIndex index="0">
-                                <numIndex index="0"></numIndex>
-                                <numIndex index="1"></numIndex>
-                            </numIndex>
-                            <numIndex index="1">
-                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.sorting</numIndex>
-                                <numIndex index="1">sorting</numIndex>
-                            </numIndex>
-                            <numIndex index="2">
-                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.name</numIndex>
-                                <numIndex index="1">name</numIndex>
-                            </numIndex>
-                            <numIndex index="3">
-                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sorting.create_date</numIndex>
-                                <numIndex index="1">create_date</numIndex>
-                            </numIndex>
-                        </items>
-                    </config>
+                    <sheetTitle>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.tab.filter</sheetTitle>
                 </TCEforms>
-            </settings.sorting>
-            <settings.sortingDirection>
-                <TCEforms>
-                    <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection</label>
-                    <config>
-                        <type>select</type>
-                        <renderType>selectSingle</renderType>
-                        <items>
-                            <numIndex index="0">
-                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.asc</numIndex>
-                                <numIndex index="1">asc</numIndex>
-                            </numIndex>
-                            <numIndex index="1">
-                                <numIndex index="0">LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.sortingDirection.desc</numIndex>
-                                <numIndex index="1">desc</numIndex>
-                            </numIndex>
-                        </items>
-                    </config>
-                </TCEforms>
-            </settings.sortingDirection>
-        </el>
-    </ROOT>
-</extra>
+                <type>array</type>
+                <el>
+                    <settings.filter.subcompany_include>
+                        <TCEforms>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_include</label>
+                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_include.description</description>
+                            <config>
+                                <type>input</type>
+                                <eval>trim</eval>
+                            </config>
+                        </TCEforms>
+                    </settings.filter.subcompany_include>
+                    <settings.filter.subcompany_exclude>
+                        <TCEforms>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_exclude</label>
+                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_exclude.description</description>
+                            <config>
+                                <type>input</type>
+                                <eval>trim</eval>
+                            </config>
+                        </TCEforms>
+                    </settings.filter.subcompany_exclude>
+                </el>
+            </ROOT>
+        </filter>
+    </sheets>
+</T3DataStructure>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -17,6 +17,13 @@
 				<source>Shows the detail view of a single job.</source>
 			</trans-unit>
 
+			<trans-unit id="flexforms.tab.settings">
+				<source>Settings</source>
+			</trans-unit>
+			<trans-unit id="flexforms.tab.filter">
+				<source>Filter</source>
+			</trans-unit>
+
 			<trans-unit id="flexforms.show.settings.listPid">
 				<source>List page</source>
 			</trans-unit>
@@ -43,6 +50,18 @@
 			</trans-unit>
 			<trans-unit id="flexforms.list.settings.sortingDirection.desc">
 				<source>descending</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.filter.subcompany_include">
+				<source>Subcompany (include)</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.filter.subcompany_include.description">
+				<source>Multiple values can be separated by comma.</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.filter.subcompany_exclude">
+				<source>Subcompany (exclude)</source>
+			</trans-unit>
+			<trans-unit id="flexforms.list.settings.filter.subcompany_exclude.description">
+				<source>Multiple values can be separated by comma.</source>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION
This PR introduces the possibility to filter jobs displayed in list plugins. As a first filter option, subcompanies can be included (whitelist) or excluded (blacklist).