### PR TITLE
[TASK] Streamline casing of flexform fields

### DIFF
--- a/Classes/Domain/Model/Dto/Filter.php
+++ b/Classes/Domain/Model/Dto/Filter.php
@@ -35,8 +35,8 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  * @license GPL-2.0-or-later
  *
  * @phpstan-type FilterSettings array{
- *     subcompany_include?: string,
- *     subcompany_exclude?: string,
+ *     subcompanyInclude?: string,
+ *     subcompanyExclude?: string,
  * }
  */
 class Filter
@@ -63,8 +63,8 @@ class Filter
     public static function fromArray(array $settings): static
     {
         $filter = new static();
-        $filter->subcompanyInclude = GeneralUtility::trimExplode(',', $settings['subcompany_include'] ?? '', true);
-        $filter->subcompanyExclude = GeneralUtility::trimExplode(',', $settings['subcompany_exclude'] ?? '', true);
+        $filter->subcompanyInclude = GeneralUtility::trimExplode(',', $settings['subcompanyInclude'] ?? '', true);
+        $filter->subcompanyExclude = GeneralUtility::trimExplode(',', $settings['subcompanyExclude'] ?? '', true);
 
         return $filter;
     }

--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -75,26 +75,26 @@
                 </TCEforms>
                 <type>array</type>
                 <el>
-                    <settings.filter.subcompany_include>
+                    <settings.filter.subcompanyInclude>
                         <TCEforms>
-                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_include</label>
-                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_include.description</description>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompanyInclude</label>
+                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompanyInclude.description</description>
                             <config>
                                 <type>input</type>
                                 <eval>trim</eval>
                             </config>
                         </TCEforms>
-                    </settings.filter.subcompany_include>
-                    <settings.filter.subcompany_exclude>
+                    </settings.filter.subcompanyInclude>
+                    <settings.filter.subcompanyExclude>
                         <TCEforms>
-                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_exclude</label>
-                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompany_exclude.description</description>
+                            <label>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompanyExclude</label>
+                            <description>LLL:EXT:personio_jobs/Resources/Private/Language/locallang_be.xlf:flexforms.list.settings.filter.subcompanyExclude.description</description>
                             <config>
                                 <type>input</type>
                                 <eval>trim</eval>
                             </config>
                         </TCEforms>
-                    </settings.filter.subcompany_exclude>
+                    </settings.filter.subcompanyExclude>
                 </el>
             </ROOT>
         </filter>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -51,16 +51,16 @@
 			<trans-unit id="flexforms.list.settings.sortingDirection.desc">
 				<source>descending</source>
 			</trans-unit>
-			<trans-unit id="flexforms.list.settings.filter.subcompany_include">
+			<trans-unit id="flexforms.list.settings.filter.subcompanyInclude">
 				<source>Subcompany (include)</source>
 			</trans-unit>
-			<trans-unit id="flexforms.list.settings.filter.subcompany_include.description">
+			<trans-unit id="flexforms.list.settings.filter.subcompanyInclude.description">
 				<source>Multiple values can be separated by comma.</source>
 			</trans-unit>
-			<trans-unit id="flexforms.list.settings.filter.subcompany_exclude">
+			<trans-unit id="flexforms.list.settings.filter.subcompanyExclude">
 				<source>Subcompany (exclude)</source>
 			</trans-unit>
-			<trans-unit id="flexforms.list.settings.filter.subcompany_exclude.description">
+			<trans-unit id="flexforms.list.settings.filter.subcompanyExclude.description">
 				<source>Multiple values can be separated by comma.</source>
 			</trans-unit>
 		</body>


### PR DESCRIPTION
Flexform fields should always be written in *lowerCamelCase*.