### PR TITLE
[!!!][FEATURE] Provide service for job import

### DIFF
--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -31,7 +31,7 @@ use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
 use CPSIT\Typo3PersonioJobs\Domain\Repository\JobRepository;
 use CPSIT\Typo3PersonioJobs\Exception\ExtensionNotLoadedException;
 use CPSIT\Typo3PersonioJobs\PageTitle\JobPageTitleProvider;
-use CPSIT\Typo3PersonioJobs\Service\PersonioService;
+use CPSIT\Typo3PersonioJobs\Service\PersonioApiService;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -50,7 +50,7 @@ class JobController extends ActionController
         protected readonly MetaTagManagerRegistry $metaTagManagerRegistry,
         protected readonly JobPageTitleProvider $pageTitleProvider,
         protected readonly CacheManager $cacheManager,
-        protected readonly PersonioService $personioService,
+        protected readonly PersonioApiService $personioApiService,
         protected readonly SchemaFactory $schemaFactory,
     ) {
     }
@@ -76,7 +76,7 @@ class JobController extends ActionController
         $this->addSchema($job);
 
         $this->view->assign('job', $job);
-        $this->view->assign('applyUrl', (string)$this->personioService->getApplyUrl($job));
+        $this->view->assign('applyUrl', (string)$this->personioApiService->getApplyUrl($job));
 
         return $this->htmlResponse();
     }

--- a/Classes/Domain/Factory/SchemaFactory.php
+++ b/Classes/Domain/Factory/SchemaFactory.php
@@ -33,7 +33,7 @@ use CPSIT\Typo3PersonioJobs\Enums\Job\Schedule;
 use CPSIT\Typo3PersonioJobs\Enums\Schema\EmploymentType as EmploymentTypeSchema;
 use CPSIT\Typo3PersonioJobs\Event\EnrichJobPostingSchemaEvent;
 use CPSIT\Typo3PersonioJobs\Exception\ExtensionNotLoadedException;
-use CPSIT\Typo3PersonioJobs\Service\PersonioService;
+use CPSIT\Typo3PersonioJobs\Service\PersonioApiService;
 use CPSIT\Typo3PersonioJobs\Utility\FrontendUtility;
 use DateTime;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -50,7 +50,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 final class SchemaFactory
 {
     public function __construct(
-        private readonly PersonioService $personioService,
+        private readonly PersonioApiService $personioApiService,
         private readonly ContentObjectRenderer $contentObjectRenderer,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
@@ -80,7 +80,7 @@ final class SchemaFactory
             ->setProperty('title', $job->getName())
             ->setProperty('description', $this->decorateDescription($job))
             ->setProperty('url', (string)$serverRequest->getUri())
-            ->setProperty('sameAs', (string)$this->personioService->getJobUrl($job))
+            ->setProperty('sameAs', (string)$this->personioApiService->getJobUrl($job))
         ;
 
         $this->eventDispatcher->dispatch(new EnrichJobPostingSchemaEvent($job, $jobPosting));

--- a/Classes/Domain/Model/Dto/ImportResult.php
+++ b/Classes/Domain/Model/Dto/ImportResult.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Domain\Model\Dto;
+
+use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
+use CPSIT\Typo3PersonioJobs\Enums\ImportOperation;
+
+/**
+ * ImportResult
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class ImportResult
+{
+    /**
+     * @var array<value-of<ImportOperation>, list<Job>>
+     */
+    private array $operations = [];
+
+    public function __construct(
+        private readonly bool $dryRun,
+    ) {
+    }
+
+    public function add(Job $job, ImportOperation $operation): self
+    {
+        $this->operations[$operation->value] ??= [];
+        $this->operations[$operation->value][] = $job;
+
+        return $this;
+    }
+
+    /**
+     * @return list<Job>
+     */
+    public function getNewJobs(): array
+    {
+        return $this->filterByOperation(ImportOperation::Added);
+    }
+
+    /**
+     * @return list<Job>
+     */
+    public function getUpdatedJobs(): array
+    {
+        return $this->filterByOperation(ImportOperation::Updated);
+    }
+
+    /**
+     * @return list<Job>
+     */
+    public function getRemovedJobs(): array
+    {
+        return $this->filterByOperation(ImportOperation::Removed);
+    }
+
+    /**
+     * @return list<Job>
+     */
+    public function getSkippedJobs(): array
+    {
+        return $this->filterByOperation(ImportOperation::Skipped);
+    }
+
+    /**
+     * @return array<value-of<ImportOperation>, list<Job>>
+     */
+    public function getAllProcessedJobs(): array
+    {
+        return $this->operations;
+    }
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    /**
+     * @return list<Job>
+     */
+    private function filterByOperation(ImportOperation $operation): array
+    {
+        return $this->importResult[$operation->value] ?? [];
+    }
+}

--- a/Classes/Exception/InvalidParametersException.php
+++ b/Classes/Exception/InvalidParametersException.php
@@ -21,25 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace CPSIT\Typo3PersonioJobs\Event;
+namespace CPSIT\Typo3PersonioJobs\Exception;
 
-use CPSIT\Typo3PersonioJobs\Domain\Model\Dto\ImportResult;
+use Exception;
 
 /**
- * AfterJobsImportedEvent
+ * InvalidParametersException
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-final class AfterJobsImportedEvent
+final class InvalidParametersException extends Exception
 {
-    public function __construct(
-        private readonly ImportResult $importResult,
-    ) {
-    }
-
-    public function getImportResult(): ImportResult
+    public static function create(string ...$parameters): self
     {
-        return $this->importResult;
+        return new self(
+            sprintf('The parameters "%s" cannot be used together.', implode('", "', $parameters)),
+            1683530338,
+        );
     }
 }

--- a/Classes/Service/PersonioApiService.php
+++ b/Classes/Service/PersonioApiService.php
@@ -41,12 +41,12 @@ use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\Uri;
 
 /**
- * PersonioService
+ * PersonioApiService
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-final class PersonioService
+final class PersonioApiService
 {
     private readonly Uri $apiUrl;
     private readonly TreeMapper $mapper;

--- a/Classes/Service/PersonioImportService.php
+++ b/Classes/Service/PersonioImportService.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "personio_jobs".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3PersonioJobs\Service;
+
+use CPSIT\Typo3PersonioJobs\Cache\CacheManager;
+use CPSIT\Typo3PersonioJobs\Domain\Model\Dto\ImportResult;
+use CPSIT\Typo3PersonioJobs\Domain\Model\Job;
+use CPSIT\Typo3PersonioJobs\Domain\Repository\JobRepository;
+use CPSIT\Typo3PersonioJobs\Enums\ImportOperation;
+use CPSIT\Typo3PersonioJobs\Event\AfterJobsImportedEvent;
+use CPSIT\Typo3PersonioJobs\Exception\InvalidParametersException;
+use CPSIT\Typo3PersonioJobs\Helper\SlugHelper;
+use Generator;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+
+/**
+ * PersonioImportService
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class PersonioImportService
+{
+    private ImportResult $result;
+
+    public function __construct(
+        private readonly CacheManager $cacheManager,
+        private readonly Connection $connection,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly JobRepository $jobRepository,
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly PersonioApiService $personioApiService,
+    ) {
+        $this->result = new ImportResult(false);
+    }
+
+    /**
+     * @param int<0, max> $storagePid
+     * @throws InvalidParametersException
+     */
+    public function import(
+        int $storagePid,
+        bool $updateExistingJobs = true,
+        bool $deleteOrphans = true,
+        bool $forceImport = false,
+        bool $dryRun = false,
+    ): ImportResult {
+        $this->result = new ImportResult($dryRun);
+
+        // Validate parameters
+        if (!$updateExistingJobs && $forceImport) {
+            throw InvalidParametersException::create('$updateExistingJobs', '$forceImport');
+        }
+
+        // Fetch jobs from Personio API
+        $jobs = $this->personioApiService->getJobs();
+        $orphans = $deleteOrphans ? $this->jobRepository->findOrphans($jobs, $storagePid) : [];
+
+        // Process imported jobs
+        foreach ($jobs as $job) {
+            $job->setPid($storagePid);
+
+            foreach ($job->getJobDescriptions() as $jobDescription) {
+                $jobDescription->setPid($storagePid);
+            }
+
+            $this->addOrUpdateJob($job, $storagePid, $forceImport, $updateExistingJobs);
+        }
+
+        // Remove orphaned jobs
+        foreach ($orphans as $orphanedJob) {
+            $this->removeJob($orphanedJob);
+        }
+
+        // Persist all changes and flush caches
+        $this->persistChanges();
+
+        return $this->result;
+    }
+
+    private function addOrUpdateJob(Job $job, int $storagePid, bool $force = false, bool $update = true): void
+    {
+        $existingJob = $this->jobRepository->findOneByPersonioId($job->getPersonioId(), $storagePid);
+
+        // Add non-existing job
+        if ($existingJob === null) {
+            $this->addJob($job);
+
+            return;
+        }
+
+        // Update changed job
+        if (($update && $existingJob->getContentHash() !== $job->getContentHash()) || $force) {
+            $this->replaceJob($existingJob, $job);
+
+            return;
+        }
+
+        // Skip unchanged job
+        $this->result->add($job, ImportOperation::Skipped);
+    }
+
+    private function addJob(Job $job): void
+    {
+        if (!$this->result->isDryRun()) {
+            $this->jobRepository->add($job);
+        }
+
+        $this->result->add($job, ImportOperation::Added);
+    }
+
+    private function replaceJob(Job $existingJob, Job $importedJob): void
+    {
+        $this->result->add($importedJob, ImportOperation::Updated);
+
+        // Early return on dry-run
+        if ($this->result->isDryRun()) {
+            return;
+        }
+
+        // Keep existing UID
+        $existingUid = $existingJob->getUid();
+        if ($existingUid !== null) {
+            $importedJob->setUid($existingUid);
+        } else {
+            $this->persistenceManager->remove($existingJob);
+        }
+
+        // Remove existing job descriptions
+        foreach ($existingJob->getJobDescriptions() as $jobDescription) {
+            $this->persistenceManager->remove($jobDescription);
+        }
+
+        // Add updated job
+        $this->persistenceManager->add($importedJob);
+    }
+
+    private function removeJob(Job $job): void
+    {
+        if (!$this->result->isDryRun()) {
+            $this->persistenceManager->remove($job);
+        }
+
+        $this->result->add($job, ImportOperation::Removed);
+    }
+
+    private function persistChanges(): void
+    {
+        // Early return on dry-run
+        if ($this->result->isDryRun()) {
+            return;
+        }
+
+        $this->persistenceManager->persistAll();
+
+        foreach ($this->getModifiedJobs() as $job) {
+            $this->updateSlug($job);
+        }
+
+        $this->eventDispatcher->dispatch(new AfterJobsImportedEvent($this->result));
+
+        $this->flushCacheTags();
+    }
+
+    private function updateSlug(Job $job): void
+    {
+        // Fetch job record
+        $record = $this->connection->select(['*'], Job::TABLE_NAME, ['uid' => $job->getUid()])->fetchAssociative();
+
+        // Early return if record cannot be fetched
+        if ($record === false) {
+            return;
+        }
+
+        // Generate slug for updated record
+        $slug = SlugHelper::generateSlug(Job::TABLE_NAME, $record);
+
+        // Update record
+        $this->connection->update(Job::TABLE_NAME, ['slug' => $slug], ['uid' => $job->getUid()]);
+    }
+
+    private function flushCacheTags(): void
+    {
+        $flushGeneralCache = false;
+
+        // Flush specific job caches (used in list and detail view)
+        foreach ($this->getModifiedJobs() as $job) {
+            $this->cacheManager->flushTag($job);
+
+            $flushGeneralCache = true;
+        }
+
+        // Flush general job cache (used in list view)
+        if ($flushGeneralCache) {
+            $this->cacheManager->flushTag();
+        }
+    }
+
+    /**
+     * @return Generator<Job>
+     */
+    private function getModifiedJobs(): Generator
+    {
+        foreach ($this->result->getNewJobs() as $newJob) {
+            yield $newJob;
+        }
+
+        foreach ($this->result->getUpdatedJobs() as $newJob) {
+            yield $newJob;
+        }
+
+        foreach ($this->result->getRemovedJobs() as $newJob) {
+            yield $newJob;
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,8 +16,6 @@ services:
       $pageCache: '@cache.pages'
 
   CPSIT\Typo3PersonioJobs\Command\ImportCommand:
-    arguments:
-      $connection: '@connection.jobs'
     tags:
       - name: 'console.command'
         command: 'personio-jobs:import'
@@ -28,6 +26,14 @@ services:
 
   CPSIT\Typo3PersonioJobs\Hooks\DataHandlerHook:
     public: true
+
+  CPSIT\Typo3PersonioJobs\Service\PersonioApiService:
+    public: true
+
+  CPSIT\Typo3PersonioJobs\Service\PersonioImportService:
+    public: true
+    arguments:
+      $connection: '@connection.jobs'
 
   cache.pages:
     class: 'TYPO3\CMS\Core\Cache\Frontend\FrontendInterface'


### PR DESCRIPTION
This PR introduces a new `PersonioImportService`. It contains the whole import logic from the import command, which is now much smaller. In addition, the following breaking changes are introduced:

- Renamed `PersonioService` to `PersonioApiService`
- Changed public methods within `AfterJobsImportedEvent`

All changes are reflected in the migration guide.