### PR TITLE
[BUGFIX] Reflect employment type "temporary"

### DIFF
--- a/Classes/Enums/Job/EmploymentType.php
+++ b/Classes/Enums/Job/EmploymentType.php
@@ -34,6 +34,7 @@ enum EmploymentType: string
     case Freelance = 'freelance';
     case Intern = 'intern';
     case Permanent = 'permanent';
+    case Temporary = 'temporary';
     case Trainee = 'trainee';
     case WorkingStudent = 'working_student';
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -31,6 +31,9 @@
 			<trans-unit id="meta.employmentType.permanent">
 				<source>Permanent</source>
 			</trans-unit>
+			<trans-unit id="meta.employmentType.temporary">
+				<source>Temporary</source>
+			</trans-unit>
 			<trans-unit id="meta.employmentType.trainee">
 				<source>Trainee</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -60,6 +60,9 @@
 			<trans-unit id="tx_personiojobs_domain_model_job.employment_type.permanent">
 				<source>Permanent</source>
 			</trans-unit>
+			<trans-unit id="tx_personiojobs_domain_model_job.employment_type.temporary">
+				<source>Temporary</source>
+			</trans-unit>
 			<trans-unit id="tx_personiojobs_domain_model_job.employment_type.trainee">
 				<source>Trainee</source>
 			</trans-unit>


### PR DESCRIPTION
This PR adds the missing employment type `temporary` to the `EmploymentType` enum.

Resolves: #46