### PR TITLE
[BUGFIX] Access correct property in ImportResult

### DIFF
--- a/Classes/Domain/Model/Dto/ImportResult.php
+++ b/Classes/Domain/Model/Dto/ImportResult.php
@@ -102,6 +102,6 @@ final class ImportResult
      */
     private function filterByOperation(ImportOperation $operation): array
     {
-        return $this->importResult[$operation->value] ?? [];
+        return $this->operations[$operation->value] ?? [];
     }
 }


### PR DESCRIPTION
This PR fixes a nasty bug where the wrong property was accessed in `ImportResult::filterByOperation()`.