### PR TITLE
[BUGFIX] Allow empty filter constraints

### DIFF
--- a/Classes/Domain/Model/Dto/Filter.php
+++ b/Classes/Domain/Model/Dto/Filter.php
@@ -72,7 +72,7 @@ class Filter
     /**
      * @param QueryInterface<Job> $query
      */
-    public function buildConstraint(QueryInterface $query): ConstraintInterface
+    public function buildConstraint(QueryInterface $query): ?ConstraintInterface
     {
         $constraints = [];
 
@@ -84,6 +84,11 @@ class Filter
             $constraints[] = $query->logicalNot(
                 $query->in('subcompany', $this->subcompanyExclude),
             );
+        }
+
+        // Early return if no constraints are defined
+        if ($constraints === []) {
+            return null;
         }
 
         return $query->logicalAnd(...$constraints);

--- a/Classes/Domain/Model/Dto/ListDemand.php
+++ b/Classes/Domain/Model/Dto/ListDemand.php
@@ -71,6 +71,11 @@ class ListDemand implements Demand
         $originalConstraint = $query->getConstraint();
         $filterConstraint = $this->filter->buildConstraint($query);
 
+        // Early return if no filter constraints are defined
+        if ($filterConstraint === null) {
+            return;
+        }
+
         if ($originalConstraint === null) {
             $query->matching($filterConstraint);
         } else {


### PR DESCRIPTION
This PR fixes a bug where an empty set of constraints was passed to `$query->logicalAnd()`. For this, the filter DTO no longer requires a valid constraint to be returned from `Filter::buildConstraint()`.