### PR TITLE
[BUGFIX] Declare supported PHP versions in `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,6 +33,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '11.5.0-12.4.99',
+            'php' => '8.1.0-8.2.99',
         ],
         'suggests' => [
             'schema' => '2.7.0-2.99.99',


### PR DESCRIPTION
For legacy installations, it's necessary to add the PHP version requirement to `ext_emconf.php`. Otherwise, errors like described in #108 may occur, because EM allows installation of the extension in an unsupported environment.