### PR TITLE
Merge tag '0.5.7' into develop

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,10 +84,34 @@ jobs:
       - name: Run tests
         run: composer test:coverage
 
-      # Report coverage
+      # Upload artifact
       - name: Fix coverage path
         working-directory: .Build/coverage
         run: sed -i 's#/home/runner/work/personio-jobs/personio-jobs#${{ github.workspace }}#g' clover.xml
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: .Build/coverage/clover.xml
+          retention-days: 7
+
+  coverage-report:
+    name: Report test coverage
+    runs-on: ubuntu-latest
+    needs: coverage
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Download artifact
+      - name: Download coverage artifact
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+
+      # CodeClimate
       - name: CodeClimate report
         uses: paambaati/codeclimate-action@v5.0.0
         if: env.CC_TEST_REPORTER_ID
@@ -95,11 +119,14 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageLocations: |
-            ${{ github.workspace }}/.Build/coverage/clover.xml:clover
+            ${{ steps.download.outputs.download-path }}/clover.xml:clover
+
+      # codecov
       - name: codecov report
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: .Build/coverage
+          files: |
+            ${{ steps.download.outputs.download-path }}/clover.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This PR extracts coverage report from coverage collection in CI. This way, coverage report can always retried on failures without the need to re-collect coverage.