### PR TITLE
[BUGFIX] Avoid cuyz/valinor 1.8.0 for the time being

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
 		"typo3/coding-standards": "^0.7.1",
 		"typo3/testing-framework": "^7.0.2 || ^8.0.1"
 	},
+	"conflict": {
+		"cuyz/valinor": "1.8.0"
+	},
 	"suggest": {
 		"brotkrueml/schema": "Include JSON schema on job detail pages (^2.7)"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7988f1ed7f001ae594c1018933377fdc",
+    "content-hash": "3b58155ab563d5f7ff3243e991783db0",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
Version `1.8.0` of `cuyz/valinor` is incompatible with this package, probably due to a bug on their side, see cuyz/valinor#461. Thus, we mark it as conflicting until the problem is solved to avoid issues for end-users.