### PR TITLE
[TASK] Drop Git Flow and use `main` as default branch

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   cgl:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
-      - '**'
+      - main
 
 jobs:
   tests:

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"local>CPS-IT/renovate-config",
-		"local>CPS-IT/renovate-config:git-flow",
 		"local>CPS-IT/renovate-config:typo3-extension"
 	],
 	"assignees": [


### PR DESCRIPTION
This PR drops Git Flow along with the `develop` branch and switches to `main` as default branch.