### PR TITLE
[TASK] Normalize composer.json in libs directory as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,10 @@
 			"@fix:editorconfig",
 			"@fix:php"
 		],
-		"fix:composer": "@composer normalize",
+		"fix:composer": [
+			"@composer normalize",
+			"@composer normalize Resources/Private/Libs/Build/composer.json"
+		],
 		"fix:editorconfig": "@lint:editorconfig --fix",
 		"fix:php": "php-cs-fixer fix",
 		"lint": [


### PR DESCRIPTION
This PR extends the `fix:composer` script to normalize `composer.json` in `Resources/Private/Libs/Build` as well.