### PR TITLE
[BUGFIX] Allow `yearsOfExperience` to be empty

### DIFF
--- a/Classes/Configuration/Tca.php
+++ b/Classes/Configuration/Tca.php
@@ -41,27 +41,27 @@ final class Tca
      * @param list<string|\BackedEnum> $itemValues
      * @return list<array{string, string}>|list<array{label: string, value: string}>
      */
-    public static function mapItems(string $tableName, string $fieldName, array $itemValues): array
-    {
-        $typo3Version = (new Typo3Version())->getMajorVersion();
+    public static function mapItems(
+        string $tableName,
+        string $fieldName,
+        array $itemValues,
+        bool $allowEmpty = false,
+    ): array {
         $items = [];
+
+        if ($allowEmpty) {
+            $items[] = self::resolveItem('', '');
+        }
 
         foreach ($itemValues as $itemValue) {
             if ($itemValue instanceof \BackedEnum) {
                 $itemValue = (string)$itemValue->value;
             }
 
-            $itemArray = [
-                'label' => 'LLL:EXT:personio_jobs/Resources/Private/Language/locallang_db.xlf:' . $tableName . '.' . $fieldName . '.' . $itemValue,
-                'value' => $itemValue,
-            ];
-
-            // @todo Remove once support for TYPO3 v11 is dropped
-            if ($typo3Version < 12) {
-                $itemArray = array_values($itemArray);
-            }
-
-            $items[] = $itemArray;
+            $items[] = self::resolveItem(
+                'LLL:EXT:personio_jobs/Resources/Private/Language/locallang_db.xlf:' . $tableName . '.' . $fieldName . '.' . $itemValue,
+                $itemValue,
+            );
         }
 
         return $items;
@@ -88,6 +88,25 @@ final class Tca
             /* @phpstan-ignore-next-line */
             $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
         }
+    }
+
+    /**
+     * @return array{label: string, value: string}|array{string, string}
+     */
+    private static function resolveItem(string $label, string $value): array
+    {
+        $typo3Version = (new Typo3Version())->getMajorVersion();
+        $item = [
+            'label' => $label,
+            'value' => $value,
+        ];
+
+        // @todo Remove once support for TYPO3 v11 is dropped
+        if ($typo3Version < 12) {
+            $item = array_values($item);
+        }
+
+        return $item;
     }
 
     private static function buildPluginSignature(string $pluginName): string

--- a/Classes/Domain/Model/Job.php
+++ b/Classes/Domain/Model/Job.php
@@ -82,7 +82,7 @@ class Job extends AbstractEntity implements \JsonSerializable
         EmploymentType $employmentType,
         Seniority $seniority,
         Schedule $schedule,
-        YearsOfExperience $yearsOfExperience,
+        ?YearsOfExperience $yearsOfExperience,
         ?string $keywords,
         ?string $occupation,
         ?string $occupationCategory,
@@ -104,7 +104,7 @@ class Job extends AbstractEntity implements \JsonSerializable
         $job->employmentType = $employmentType->value;
         $job->seniority = $seniority->value;
         $job->schedule = $schedule->value;
-        $job->yearsOfExperience = $yearsOfExperience->value;
+        $job->yearsOfExperience = $yearsOfExperience->value ?? '';
         $job->keywords = (string)$keywords;
         $job->occupation = (string)$occupation;
         $job->occupationCategory = (string)$occupationCategory;

--- a/Configuration/TCA/tx_personiojobs_domain_model_job.php
+++ b/Configuration/TCA/tx_personiojobs_domain_model_job.php
@@ -256,6 +256,7 @@ $tca = [
                     \CPSIT\Typo3PersonioJobs\Domain\Model\Job::TABLE_NAME,
                     'years_of_experience',
                     \CPSIT\Typo3PersonioJobs\Enums\Job\YearsOfExperience::cases(),
+                    true,
                 ),
             ],
         ],

--- a/Tests/Unit/Fixtures/Files/api-response-no-working-experience.xml
+++ b/Tests/Unit/Fixtures/Files/api-response-no-working-experience.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+    <position>
+        <id>1</id>
+        <subcompany>Test company</subcompany>
+        <office>Berlin</office>
+        <department>IT</department>
+        <recruitingCategory>Testing</recruitingCategory>
+        <name>Software tester (f/m/x)</name>
+        <jobDescriptions>
+            <jobDescription>
+                <name>Hello World!</name>
+                <value>
+                    <![CDATA[<strong>Lorem ipsum dolor sit amet.</strong>]]>
+                </value>
+            </jobDescription>
+            <jobDescription>
+                <name>See you soon!</name>
+                <value>
+                    <![CDATA[<strong>Lorem ipsum dolor sit amet.</strong>]]>
+                </value>
+            </jobDescription>
+        </jobDescriptions>
+        <employmentType>permanent</employmentType>
+        <seniority>experienced</seniority>
+        <schedule>full-time</schedule>
+        <keywords>Testing,QA,Fun</keywords>
+        <occupation>software_and_web_development</occupation>
+        <occupationCategory>it_software</occupationCategory>
+        <createdAt>2023-08-11T14:15:17+00:00</createdAt>
+    </position>
+</workzag-jobs>

--- a/Tests/Unit/Service/PersonioApiServiceTest.php
+++ b/Tests/Unit/Service/PersonioApiServiceTest.php
@@ -132,6 +132,21 @@ final class PersonioApiServiceTest extends UnitTestCase
         self::assertJobEqualsJob($this->createJob(2), $actual[1]);
     }
 
+    /**
+     * @test
+     */
+    public function getJobsReturnsMappedJobObjectWithoutWorkingExperience(): void
+    {
+        $stream = $this->streamFactory->createStreamFromFile(dirname(__DIR__) . '/Fixtures/Files/api-response-no-working-experience.xml');
+
+        $this->requestFactory->response = new Response($stream);
+
+        $actual = $this->subject->getJobs();
+
+        self::assertCount(1, $actual);
+        self::assertJobEqualsJob($this->createJob(1, null), $actual[0]);
+    }
+
     private static function assertJobEqualsJob(Job $expected, Job $actual): void
     {
         // Create expected job descriptions
@@ -160,7 +175,7 @@ final class PersonioApiServiceTest extends UnitTestCase
         self::assertEquals($expectedJobDescription2->setJob($actual), $actualJobDescriptions[1]);
     }
 
-    private function createJob(int $id): Job
+    private function createJob(int $id, ?YearsOfExperience $yearsOfExperience = YearsOfExperience::TwoFiveYears): Job
     {
         $job = (new Job())
             ->setPersonioId($id)
@@ -172,7 +187,7 @@ final class PersonioApiServiceTest extends UnitTestCase
             ->setEmploymentType(EmploymentType::Permanent->value)
             ->setSeniority(Seniority::Experienced->value)
             ->setSchedule(Schedule::FullTime->value)
-            ->setYearsOfExperience(YearsOfExperience::TwoFiveYears->value)
+            ->setYearsOfExperience($yearsOfExperience->value ?? '')
             ->setKeywords('Testing,QA,Fun')
             ->setOccupation('software_and_web_development')
             ->setOccupationCategory('it_software')

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 			path: Classes/Service/PersonioApiService.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(int, string\\|null, string\\|null, string\\|null, string\\|null, string, array\\{jobDescription\\: list\\<CPSIT\\\\Typo3PersonioJobs\\\\Domain\\\\Model\\\\JobDescription\\>\\}, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\EmploymentType, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\Seniority, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\Schedule, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\YearsOfExperience, string\\|null, string\\|null, string\\|null, DateTime\\)\\: CPSIT\\\\Typo3PersonioJobs\\\\Domain\\\\Model\\\\Job given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$constructors of method CuyZ\\\\Valinor\\\\MapperBuilder\\:\\:registerConstructor\\(\\) expects \\(pure\\-callable\\(\\)\\: mixed\\)\\|class\\-string, Closure\\(int, string\\|null, string\\|null, string\\|null, string\\|null, string, array\\{jobDescription\\: list\\<CPSIT\\\\Typo3PersonioJobs\\\\Domain\\\\Model\\\\JobDescription\\>\\}, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\EmploymentType, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\Seniority, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\Schedule, CPSIT\\\\Typo3PersonioJobs\\\\Enums\\\\Job\\\\YearsOfExperience\\|null, string\\|null, string\\|null, string\\|null, DateTime\\)\\: CPSIT\\\\Typo3PersonioJobs\\\\Domain\\\\Model\\\\Job given\\.$#"
 			count: 1
 			path: Classes/Service/PersonioApiService.php
 


### PR DESCRIPTION
Although [documented differently](https://developer.personio.de/reference/get_xml), `yearsOfExperience` can be empty. This PR changes the mapping of this field to allow being empty/unset.